### PR TITLE
Fix error preventing unicode in street address

### DIFF
--- a/djangocms_gmaps/models.py
+++ b/djangocms_gmaps/models.py
@@ -179,7 +179,7 @@ class Location(CMSPlugin):
             'zoom': 17,
             'lat': coordinates[0],
             'lng': coordinates[1],
-            'address': quote_plus(self.address)
+            'address': quote_plus(self.address.encode('utf-8'), safe=':/')
         }
         return u'http://maps.google.com/maps' \
                u'?f=d&z=%(zoom)s&ll=%(lat)s,%(lng)s' \

--- a/djangocms_gmaps/models.py
+++ b/djangocms_gmaps/models.py
@@ -179,7 +179,7 @@ class Location(CMSPlugin):
             'zoom': 17,
             'lat': coordinates[0],
             'lng': coordinates[1],
-            'address': quote_plus(self.address.encode('utf-8'), safe=':/')
+            'address': quote_plus(self.address.encode('utf-8'))
         }
         return u'http://maps.google.com/maps' \
                u'?f=d&z=%(zoom)s&ll=%(lat)s,%(lng)s' \


### PR DESCRIPTION
Ensure quote_plus can be used with unicode

on urllib.quote_plus: https://docs.python.org/2/library/urllib.html#urllib.quote_plus